### PR TITLE
Update GHCJS "Hello world" build instructions to use --target=javascript-ghcjs

### DIFF
--- a/blog/2022-12-13-ghc-js-backend-merged.md
+++ b/blog/2022-12-13-ghc-js-backend-merged.md
@@ -458,7 +458,7 @@ git submodule update --init --recursive
 #### Boot and Configure for JavaScript
 
 ```
-./boot && emconfigure ./configure --target=js-unknown-ghcjs
+./boot && emconfigure ./configure --target=javascript-ghcjs
 ```
 
 You should see `configure` finish and report something similar:
@@ -471,7 +471,7 @@ Configure completed successfully.
 
    Build platform        : x86_64-unknown-linux
    Host platform         : x86_64-unknown-linux
-   Target platform       : js-unknown-ghcjs
+   Target platform       : javascript-ghcjs
 
    Bootstrapping using   : /nix/store/4bkmkc7c98m4qyszsshnw9iclzzmdn4n-ghc-9.2.3-with-packages/bin/ghc
       which is version   : 9.2.3


### PR DESCRIPTION
This PR updates this doc: https://engineering.iog.io/2022-12-13-ghc-js-backend-merged/#build

Attempting to configure GHC with the `--target=js-unknown-ghcjs` produces an error "Unknown machine `js-unknown-ghcjs`".

It took some searching through GHC's configure.sub, but ultimately I learned that the target to use in 2023 is `javascript-ghcjs`.